### PR TITLE
Fixed error when try to send media as first message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup, find_packages
 import yowsup
 import platform
 import sys
-import time
 
 deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six']
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup, find_packages
 import yowsup
 import platform
 import sys
+import time
 
 deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six']
 

--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -22,6 +22,7 @@ from axolotl.protocol.senderkeydistributionmessage import SenderKeyDistributionM
 
 import logging
 import copy
+import sys
 logger = logging.getLogger(__name__)
 
 class AxolotlReceivelayer(AxolotlBaseLayer):
@@ -166,6 +167,9 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
     def parseAndHandleMessageProto(self, encMessageProtocolEntity, serializedData):
         node = encMessageProtocolEntity.toProtocolTreeNode()
         m = Message()
+        print(sys.version_info)
+        if sys.version_info >= (3,0):
+            serializedData = serializedData.encode() 
         handled = False
         try:
             m.ParseFromString(serializedData)

--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -167,7 +167,6 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
     def parseAndHandleMessageProto(self, encMessageProtocolEntity, serializedData):
         node = encMessageProtocolEntity.toProtocolTreeNode()
         m = Message()
-        print(sys.version_info)
         if sys.version_info >= (3,0):
             serializedData = serializedData.encode() 
         handled = False

--- a/yowsup/layers/axolotl/layer_send.py
+++ b/yowsup/layers/axolotl/layer_send.py
@@ -67,6 +67,8 @@ class AxolotlSendLayer(AxolotlBaseLayer):
             else:
                 messageData = self.serializeToProtobuf(node)
                 # print (messageData)
+                if not self.store.containsSession(recipient_id, 1):
+                    self.getKeysFor([node["to"]], lambda successJids, b: self.sendToContact(node) if len(successJids) == 1 else self.toLower(node), lambda: self.toLower(node))
                 if messageData:
                     sessionCipher = self.getSessionCipher(recipient_id)
                     messageData = messageData.SerializeToString() + self.getPadding()


### PR DESCRIPTION
When I try to send a media Message as first message i get the error message below. That was an key exchange error, so I added a line to fixe that.
```
    ciphertext = sessionCipher.encrypt(messageData)
  File "/usr/local/lib/python3.5/site-packages/axolotl/sessioncipher.py", line 49, in encrypt
    senderEphemeral = sessionState.getSenderRatchetKey()
  File "/usr/local/lib/python3.5/site-packages/axolotl/state/sessionstate.py", line 66, in getSenderRatchetKey
    return Curve.decodePoint(bytearray(self.sessionStructure.senderChain.senderRatchetKey), 0)
  File "/usr/local/lib/python3.5/site-packages/axolotl/ecc/curve.py", line 34, in decodePoint
    type = _bytes[0]  # byte appears to be automatically converted to an integer??
IndexError: bytearray index out of range
```
On Layer_receive.py, I added a version checker to handle received messages on python 3.0 or greater 