### PR TITLE
Delete the .enc file

### DIFF
--- a/yowsup/layers/protocol_media/mediauploader.py
+++ b/yowsup/layers/protocol_media/mediauploader.py
@@ -100,8 +100,7 @@ class MediaUploader(WARequest, threading.Thread):
             fenc.seek(0, 2)
             filesize=fenc.tell()
             fenc.close()
-            print(sourcePath+".enc")
-            #os.remove(sourcePath+".enc")
+            os.remove(sourcePath+".enc")
             filesize2=len(stream)
 
             sha1 = hashlib.sha256()


### PR DESCRIPTION
By deleting the .env file after it's been processed, this will prevent stale files hanging around the file system. 
Also removes a print function not needed which just outputs the .enc filename