### PR TITLE
Only encode a string object, not a byte object

### DIFF
--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -190,7 +190,7 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
         node = encMessageProtocolEntity.toProtocolTreeNode()
         m = Message()
         try:
-            if sys.version_info >= (3,0):
+            if sys.version_info >= (3,0) and isinstance(serializedData, str):
                 serializedData = serializedData.encode()
         except AttributeError:
             logger.warning("AttributeError: 'bytes' object has no attribute 'encode'. Skipping 'encode()'")


### PR DESCRIPTION
Since the recent changes, `serializedData` is passed in as a byte object and I see a lot of these errors, for each message:
`WARNING:yowsup.layers.axolotl.layer_receive:AttributeError: 'bytes' object has no attribute 'encode'. Skipping 'encode()'`

This adds a small check to only encode a string object, as a byte object does not have the encode() method.