### PR TITLE
 Added missing function to AxolotlReceivelayer

### DIFF
--- a/yowsup/layers/axolotl/layer_control.py
+++ b/yowsup/layers/axolotl/layer_control.py
@@ -135,6 +135,4 @@ class AxolotlControlLayer(AxolotlBaseLayer):
         _id = format(_id, 'x')
         zfiller = len(_id) if len(_id) % 2 == 0 else len(_id) + 1
         _id = _id.zfill(zfiller if zfiller > 6 else 6)
-        # if len(_id) % 2:
-        #     _id = "0" + _id
         return binascii.unhexlify(_id)

--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -401,3 +401,9 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
 
     def adjustArray(self, arr):
         return HexUtil.decodeHex(binascii.hexlify(arr))
+
+    def adjustId(self, _id):
+        _id = format(_id, 'x')
+        zfiller = len(_id) if len(_id) % 2 == 0 else len(_id) + 1
+        _id = _id.zfill(zfiller if zfiller > 6 else 6)
+        return binascii.unhexlify(_id)


### PR DESCRIPTION
The `adjustId` function is needed inside the AxolotlReceivelayer class