### PR TITLE
Use generateIdentity() function from Tools class

### DIFF
--- a/yowsup/demos/echoclient/layer.py
+++ b/yowsup/demos/echoclient/layer.py
@@ -1,4 +1,5 @@
 from yowsup.layers.interface                           import YowInterfaceLayer, ProtocolEntityCallback
+from yowsup.common.tools                               import WATools
 import logging
 logger = logging.getLogger(__name__)
 
@@ -28,22 +29,23 @@ class EchoLayer(YowInterfaceLayer):
     def onMediaMessage(self, messageProtocolEntity):
         if not os.path.exists("/tmp/yowfiles"):
             os.makedirs("/tmp/yowfiles")
+
         if messageProtocolEntity.getMediaType() == "image":
             logger.info("Echoing image %s to %s" % (messageProtocolEntity.url, messageProtocolEntity.getFrom(False)))
             data = messageProtocolEntity.getMediaContent()
-            f = open("/tmp/yowfiles/%s%s" % (self.generateIdentity(), messageProtocolEntity.getExtension()), 'wb')
+            f = open("/tmp/yowfiles/%s%s" % (WATools.generateIdentity(), messageProtocolEntity.getExtension()), 'wb')
             f.write(data)
             f.close()
         elif messageProtocolEntity.getMediaType() == "video":
             logger.info("Echoing video %s to %s" % (messageProtocolEntity.url, messageProtocolEntity.getFrom(False)))
             data = messageProtocolEntity.getMediaContent()
-            f = open("/tmp/yowfiles/%s%s" % (self.generateIdentity(), messageProtocolEntity.getExtension()), 'wb')
+            f = open("/tmp/yowfiles/%s%s" % (WATools.generateIdentity(), messageProtocolEntity.getExtension()), 'wb')
             f.write(data)
             f.close()
         elif messageProtocolEntity.getMediaType() == "audio":
             logger.info("Echoing audio %s to %s" % (messageProtocolEntity.url, messageProtocolEntity.getFrom(False)))
             data = messageProtocolEntity.getMediaContent()
-            f = open("/tmp/yowfiles/%s%s" % (self.generateIdentity(), messageProtocolEntity.getExtension()), 'wb')
+            f = open("/tmp/yowfiles/%s%s" % (WATools.generateIdentity(), messageProtocolEntity.getExtension()), 'wb')
             f.write(data)
             f.close()
         elif messageProtocolEntity.getMediaType() == "document":
@@ -54,7 +56,5 @@ class EchoLayer(YowInterfaceLayer):
             f.close()
         elif messageProtocolEntity.getMediaType() == "location":
             logger.info("Echoing location (%s, %s) to %s" % (messageProtocolEntity.getLatitude(), messageProtocolEntity.getLongitude(), messageProtocolEntity.getFrom(False)))
-
         elif messageProtocolEntity.getMediaType() == "vcard":
             logger.info("Echoing vcard (%s, %s) to %s" % (messageProtocolEntity.getName(), messageProtocolEntity.getCardData(), messageProtocolEntity.getFrom(False)))
-


### PR DESCRIPTION
The generateIdentity() function does not exist in the EchoLayer class, need to use from the tools. The same functionality exists in `WACodeRequest` class, which also uses the `generateIdentity` function call.