### PR TITLE
Cleaned up the logger config

### DIFF
--- a/yowsup-cli
+++ b/yowsup-cli
@@ -79,17 +79,24 @@ class YowArgParser(argparse.ArgumentParser):
     def process(self):
         self.args = vars(self.parse_args())
 
-        if self.args["debug"]:
-            logging.basicConfig(level = logging.DEBUG)
+        # set the logging level
+        loggingLevel = logging.DEBUG if self.args["debug"] else logging.INFO
+
+        # log to file argument is set
+        if self.args["logfile"]:
+            # check if folder is writable
+            if not os.access(os.path.dirname(self.args["logfile"]), os.W_OK):
+                print("Folder %s is not writable" % (os.path.dirname(self.args["logfile"])))
+                sys.exit(1)
+
+            # set the logger config
+            logging.basicConfig(level = loggingLevel, format='%(asctime)s %(levelname)s %(message)s', filename=self.args["logfile"])
+
+            # if debug argument, add a stream handler to the logger
+            if self.args["debug"]:
+                logging.getLogger().addHandler(logging.StreamHandler())
         else:
-            if self.args["logfile"]:
-                if os.access(os.path.dirname(self.args["logfile"]), os.W_OK):
-                    logging.basicConfig(level = logging.INFO, format='%(asctime)s %(levelname)s %(message)s', filename=self.args["logfile"])
-                else:
-                    print("Folder %s is not writable" % (os.path.dirname(self.args["logfile"])))
-                    sys.exit(1)
-            else:
-                logging.basicConfig(level = logging.INFO)
+            logging.basicConfig(level = loggingLevel)
 
         if self.args["version"]:
             print("yowsup-cli v%s\nUsing yowsup v%s" % (__version__, yowsup.__version__))


### PR DESCRIPTION
In `yowsup-cli`, cleaned up the logfile argument setting. 
When logging to a file in debug mode, also outputs to screen (as debug is generally used for testing and bug finding, to stream to screen and output to file makes more sense).

Example commands for `yowsup-cli` are now:
`yowsup-cli demos -v` (logs from info levels to screen)
`yowsup-cli demos -v --debug` (logs from debug levels to screen)
`yowsup-cli demos -v -L /tmp/yowsup-cli.log` (logs from info levels to file)
`yowsup-cli demos -v --debug -L /tmp/yowsup-cli.log` (logs from debug levels to screen and file)