### PR TITLE
Removed reference to missing error handler.

### DIFF
--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -421,7 +421,7 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
                                             signedKeyTuple, preKeysDict, Curve.DJB_TYPE, self.adjustId(registrationId))
 
         onResult = lambda _, __: self.persistKeys(registrationId, identityKeyPair, preKeys, signedPreKey, fresh)
-        self._sendIq(setKeysIq, onResult, self.onSentKeysError)
+        self._sendIq(setKeysIq, onResult) # TODO: reintroduce error handler (was _sendIq(setKeysIq, onResult, self.onSentKeysError))
 
     def persistKeys(self, registrationId, identityKeyPair, preKeys, signedPreKey, fresh):
         total = len(preKeys)


### PR DESCRIPTION
I do not know why this error handler was removed, but the dangling reference stops me from using yowsup in https://github.com/hoehermann/wxpyWha.